### PR TITLE
Fix release workflow for multi-platform wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ permissions:
   contents: read
 
 ###############################################################################
-# Build wheels for Linux, macOS (x86_64 & arm64), and Windows (x86 & x64)
-# across Python versions 3.7 through 3.13.
+# Build wheels for Linux (x86_64 & aarch64), macOS (arm64 & x86_64),
+# and Windows (x86 & x64) across Python versions 3.7 through 3.13.
 ###############################################################################
 jobs:
-  # ---------- Linux (x86_64 + aarch64) --------------------------------------
-  linux-wheels:
+  # ---------- Linux x86_64 --------------------------------------------------
+  linux-x86-wheels:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +23,59 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: linux-cargo-${{ hashFiles('Cargo.lock') }}
+          key: linux-x86-cargo-${{ hashFiles('Cargo.lock') }}
 
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: linux-pip-${{ hashFiles('pyproject.toml') }}
+          key: linux-x86-pip-${{ hashFiles('pyproject.toml') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - name: Build Linux x86_64 wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_BEFORE_ALL_LINUX: |
+            curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-x86_64
+          path: dist/*.whl
+
+  # ---------- Linux aarch64 -------------------------------------------------
+  linux-arm-wheels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: linux-arm-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: linux-arm-pip-${{ hashFiles('pyproject.toml') }}
 
       - uses: actions/setup-python@v5
         with:
@@ -49,18 +96,18 @@ jobs:
         with:
           platforms: all
 
-      - name: Build Linux wheels
+      - name: Build Linux aarch64 wheels
         run: python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_LINUX: "aarch64"
           CIBW_BEFORE_ALL_LINUX: |
             curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux
+          name: wheels-linux-aarch64
           path: dist/*.whl
 
   # ---------- macOS arm64 ---------------------------------------------------
@@ -218,7 +265,8 @@ jobs:
   # ---------- publish -------------------------------------------------------
   publish:
     needs:
-      - linux-wheels
+      - linux-x86-wheels
+      - linux-arm-wheels
       - macos-arm64-wheels
       - macos-x86-wheels
       - windows-amd64-wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,54 +4,237 @@ on:
   push:
     tags: ['v*']
 
+permissions:
+  contents: read
+
+###############################################################################
+# Build wheels for Linux, macOS (x86_64 & arm64), and Windows (x86 & x64)
+# across Python versions 3.7 through 3.13.
+###############################################################################
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - os: macos-13
-            target: x86_64-apple-darwin
-          - os: macos-14
-            target: aarch64-apple-darwin
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
+  # ---------- Linux (x86_64 + aarch64) --------------------------------------
+  linux-wheels:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: linux-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: linux-pip-${{ hashFiles('pyproject.toml') }}
+
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install uv and maturin
+          python-version: '3.12'
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install build tools
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          pip install maturin
-      - name: Build wheels
-        run: |
-          uv run --python ${{ matrix.python-version }} maturin build --release --target ${{ matrix.target }} --out dist
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build Linux wheels
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_BEFORE_ALL_LINUX: |
+            curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
+
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-linux
           path: dist/*.whl
 
+  # ---------- macOS arm64 ---------------------------------------------------
+  macos-arm64-wheels:
+    runs-on: macos-latest
+    env:
+      CIBW_ARCHS_MACOS: "arm64"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: mac-arm-pip-${{ hashFiles('pyproject.toml') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - name: Build macOS arm64 wheels
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-mac-arm64
+          path: dist/*.whl
+
+  # ---------- macOS x86_64 --------------------------------------------------
+  macos-x86-wheels:
+    runs-on: macos-latest
+    env:
+      CIBW_ARCHS_MACOS: "x86_64"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BEFORE_ALL_MACOS: |
+        rustup target add x86_64-apple-darwin
+      CIBW_ENVIRONMENT_MACOS: "PATH=$HOME/.cargo/bin:$PATH"
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: mac-x86-pip-${{ hashFiles('pyproject.toml') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - name: Build macOS x86_64 wheels
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-mac-x86_64
+          path: dist/*.whl
+
+  #############################################################################
+  # Windows x64 --------------------------------------------------------------
+  #############################################################################
+  windows-amd64-wheels:
+    runs-on: windows-latest
+    env:
+      CIBW_ARCHS_WINDOWS: "AMD64"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: win64-pip-${{ hashFiles('pyproject.toml') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - name: Build Windows x64 wheels
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-win-amd64
+          path: dist\*.whl
+
+  #############################################################################
+  # Windows x86 --------------------------------------------------------------
+  #############################################################################
+  windows-x86-wheels:
+    runs-on: windows-latest
+    env:
+      CIBW_ARCHS_WINDOWS: "x86"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: win32-pip-${{ hashFiles('pyproject.toml') }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tools
+        run: |
+          python -m pip install -U pip
+          pip install cibuildwheel maturin
+
+      - name: Build Windows x86 wheels
+        run: python -m cibuildwheel --output-dir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-win-x86
+          path: dist\*.whl
+
+  # ---------- sdist ---------------------------------------------------------
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build sdist
+        run: |
+          python -m pip install -U build
+          python -m build --sdist --outdir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  # ---------- publish -------------------------------------------------------
   publish:
-    needs: build
+    needs:
+      - linux-wheels
+      - macos-arm64-wheels
+      - macos-x86-wheels
+      - windows-amd64-wheels
+      - windows-x86-wheels
+      - sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: dist
-          pattern: wheels-*
+          pattern: "*"
           merge-multiple: true
-      - name: Publish to PyPI
-        run: |
-          pip install maturin
-          maturin upload --skip-existing dist/*
-        env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          MATURIN_USERNAME: __token__
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: .
+          skip-existing: true


### PR DESCRIPTION
## Summary
- build wheels for Python 3.7-3.13 on Linux, macOS (arm64 & x86_64), and Windows (x86 & x64)
- publish built artifacts and sdist to PyPI

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e2601d550832c897f74e5c57a5889