### PR TITLE
chore: drop Python 3.7 from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 ###############################################################################
 # Build wheels for Linux (x86_64 & aarch64), macOS (arm64 & x86_64),
-# and Windows (x86 & x64) across Python versions 3.7 through 3.13.
+# and Windows (x86 & x64) across Python versions 3.8 through 3.13.
 ###############################################################################
 jobs:
   # ---------- Linux x86_64 --------------------------------------------------
@@ -48,7 +48,7 @@ jobs:
       - name: Build Linux x86_64 wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_BEFORE_ALL_LINUX: |
             curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
@@ -99,7 +99,7 @@ jobs:
       - name: Build Linux aarch64 wheels
         run: python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_ARCHS_LINUX: "aarch64"
           CIBW_BEFORE_ALL_LINUX: |
             curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
@@ -115,7 +115,7 @@ jobs:
     runs-on: macos-latest
     env:
       CIBW_ARCHS_MACOS: "arm64"
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
     steps:
       - uses: actions/checkout@v4
 
@@ -146,7 +146,7 @@ jobs:
     runs-on: macos-latest
     env:
       CIBW_ARCHS_MACOS: "x86_64"
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
       CIBW_BEFORE_ALL_MACOS: |
         rustup target add x86_64-apple-darwin
       CIBW_ENVIRONMENT_MACOS: "PATH=$HOME/.cargo/bin:$PATH"
@@ -183,7 +183,7 @@ jobs:
     runs-on: windows-latest
     env:
       CIBW_ARCHS_WINDOWS: "AMD64"
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
     steps:
       - uses: actions/checkout@v4
 
@@ -216,7 +216,7 @@ jobs:
     runs-on: windows-latest
     env:
       CIBW_ARCHS_WINDOWS: "x86"
-      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- remove Python 3.7 from release workflow

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e29e48c6c832c9434a9f11e51ec02