### PR TITLE
Fix merge condition for multiplier merges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ fn try_merge(a: i32, b: i32, adjacent: bool, below: &[i32]) -> Option<(i32, i32)
         return Some((a * 2, a * 2));
     }
     // 数值 + 倍增
-    if a * b < 0 && adjacent && below.iter().all(|&v| v == 0) {
+    if a * b < 0 && adjacent && (below.is_empty() || below.iter().all(|&v| v != 0)) {
         let num = if a > 0 { a } else { b };
         let mul = if a < 0 { a } else { b };
         let v = num * mul.abs();


### PR DESCRIPTION
## Summary
- ensure value+multiplier merges only occur when there are no empty spaces beneath

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e9294a728832c8835654d2b2c61f2