### PR TITLE
Add MIT license metadata to manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "akioi-2048"
 edition = "2024"
 rust-version = "1.88"
+license = "MIT"
 
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "akioi backend: one-step pure function for RL or search"
 authors = [{ name = "jasonxue" }]
 requires-python = ">=3.8,<3.14"
 readme = "README.md"
+license = {file = "LICENSE"}
 
 [build-system]
 requires = ["maturin>=1.9.3"]


### PR DESCRIPTION
## Summary
- specify MIT license in `Cargo.toml`
- reference LICENSE file in `pyproject.toml`

## Testing
- `cargo metadata --format-version=1 | jq '.packages[] | select(.name=="akioi-2048") | {name, license}'`
- `maturin build`
- `maturin develop`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e95f0ed28832c87f77cf41137fc92