### PR TITLE
Add tests for 2 and negative multiplier merges

### DIFF
--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -7,3 +7,81 @@ def test_step_smoke():
     assert len(new_board) == 4 and all(len(r) == 4 for r in new_board)
     assert isinstance(delta, int)
     assert msg in (-1, 0, 1)
+
+
+def test_number_merges_and_positive_score():
+    board = [
+        [2, 0, 0, 0],
+        [2, 0, 0, 0],
+        [4, 0, 0, 0],
+        [4, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[3][0] == 8
+    assert new_board[2][0] == 4
+    assert delta == 12
+
+
+def test_multiplier_merges_and_negative_score():
+    board = [
+        [-1, 0, 0, 0],
+        [-1, 0, 0, 0],
+        [-2, 0, 0, 0],
+        [-2, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[3][0] == -4
+    assert new_board[2][0] == -2
+    assert delta == -6
+
+
+def test_no_merge_for_negative_four():
+    board = [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [-4, 0, 0, 0],
+        [-4, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board == board
+    assert delta == 0
+
+
+def test_down_move_without_merge():
+    board = [
+        [-1, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[3][0] == -1
+    assert new_board[3][1] == 2
+    assert delta == 0
+
+
+def test_number_and_multiplier_do_not_merge_without_tiles_below():
+    board = [
+        [2, 0, 0, 0],
+        [-2, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[2][0] == 2
+    assert new_board[3][0] == -2
+    assert delta == 0
+
+
+def test_number_and_multiplier_no_merge_with_gap():
+    board = [
+        [2, 0, 0, 0],
+        [-2, 0, 0, 0],
+        [0, 0, 0, 0],
+        [16, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[1][0] == 2
+    assert new_board[2][0] == -2
+    assert new_board[3][0] == 16
+    assert delta == 0


### PR DESCRIPTION
## Summary
- clarify that downward moves should not merge `2` with `-2`, expecting no score change

## Testing
- `cargo fmt --all`
- `cargo test`
- `uv run pytest` *(fails: expected 2 and -2 to stay separate)*

------
https://chatgpt.com/codex/tasks/task_e_689e929143e0832c8c564aa8c2ab151b