### PR TITLE
Align stub docs and bodies for Python API

### DIFF
--- a/akioi_2048/__init__.pyi
+++ b/akioi_2048/__init__.pyi
@@ -9,7 +9,7 @@ def step(board: List[List[int]], direction: int) -> Tuple[List[List[int]], int, 
         * **Positive values** → Normal value tiles (2, 4, 8, …)
         * **Negative values** → Multiplier tiles  -1=×1, -2=×2, -4=×4; absolute value is the multiplier.
 
-    :param int dir:
+    :param int direction:
         Move direction:
         * `0` = **Down**  ↓
         * `1` = **Right** →
@@ -28,7 +28,7 @@ def step(board: List[List[int]], direction: int) -> Tuple[List[List[int]], int, 
         If the move is invalid (board unchanged),
         **no new tile is generated**, `delta_score = 0`, and `msg = 0`.
     """
-    pass
+    ...
 
 def init() -> List[List[int]]:
     """
@@ -37,4 +37,4 @@ def init() -> List[List[int]]:
     :returns: *new_board*
         * **new_board** `list[list[int]]` A new board
     """
-    pass
+    ...


### PR DESCRIPTION
## Summary
- Replace `dir` doc parameter with `direction` for clarity
- Use ellipsis in `step` and `init` stubs instead of `pass`

## Testing
- `ruff format akioi_2048/__init__.pyi`
- `maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea0fee76c832ca0ecda2c68b7acc4