### PR TITLE
ci: add linting and markdown checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Format Rust code
+cargo fmt --all
+
+# Format Python code
+uv run --python 3.12 ruff format
+
+# Format Markdown files
+files=$(git ls-files '*.md')
+if [ -n "$files" ]; then
+  for f in $files; do
+    cat "$f" | npx -y @fsouza/prettierd "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  done
+fi
+
+# Ensure all files are added after formatting
+git add -A

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           pip install maturin
+      - name: Ruff check
+        run: |
+          uv run --python 3.12 ruff check .
+      - name: Cargo check
+        run: |
+          cargo check --all
+      - name: Mado check
+        uses: akiomik/mado@v0.3.0
       - name: Build extension
         run: |
           uv run --python 3.12 maturin develop --release

--- a/.mado.toml
+++ b/.mado.toml
@@ -1,0 +1,49 @@
+[lint]
+output-format = "concise"
+respect-ignore = true
+respect-gitignore = true
+rules = [
+  "MD001",
+  "MD002",
+  "MD003",
+  "MD004",
+  "MD005",
+  "MD006",
+  "MD009",
+  "MD010",
+  "MD012",
+  "MD013",
+  "MD014",
+  "MD018",
+  "MD019",
+  "MD020",
+  "MD021",
+  "MD022",
+  "MD023",
+  "MD024",
+  "MD025",
+  "MD026",
+  "MD027",
+  "MD028",
+  "MD029",
+  "MD030",
+  "MD031",
+  "MD032",
+  "MD033",
+  "MD034",
+  "MD035",
+  "MD036",
+  "MD037",
+  "MD038",
+  "MD039",
+  "MD040",
+  "MD041",
+  "MD046",
+  "MD047",
+]
+
+[lint.md013]
+line-length = 120
+
+[lint.md024]
+allow-different-nesting = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@
 
 - Format Rust code with `cargo fmt --all` before committing.
 - Format Python code with `ruff format`.
+- Format Markdown with `npx @fsouza/prettierd`.
+- Run `cargo check`, `ruff check .`, and `mado check .` before pushing.
 - Run `maturin develop` followed by `pytest` to execute the full test suite.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # akioi-2048
 
-
 Python implementation of a customizable 2048 engine with multiplier tiles and score tracking. Requires Python 3.8 or later.
 
 ## Features
@@ -24,7 +23,7 @@ Apply one move. If the board changes, a new tile is spawned in a random empty ce
     - `-1` = ×1
     - `-2` = ×2
     - `-4` = ×4
-    The absolute value is the multiplier.
+      The absolute value is the multiplier.
 
 - **`direction: int`** – Movement direction
   - `0` → **Down** ↓
@@ -61,4 +60,4 @@ Install via `pip`:
 
 ```bash
 pip3 install akioi-2048
-````
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ dev = [
     "pytest>=7.4.4,<8",
     "ruff>=0.12.9",
 ]
+
+[tool.ruff.lint]
+ignore = ["F401", "F403"]


### PR DESCRIPTION
## Summary
- run Ruff, cargo, and Mado checks in CI
- add pre-commit hook formatting Rust, Python, and Markdown
- configure Ruff and Mado for repository

## Testing
- `uv run --python 3.12 ruff check .`
- `cargo check --all`
- `/tmp/mado check .`
- `uv run --python 3.12 pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea95e1fd8832c918e15d0d9ea8b85