### PR TITLE
Validate board tiles and test invalid inputs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,22 @@ enum Action {
     Right,
 }
 
+fn validate_board(board: &Board) -> PyResult<()> {
+    for row in board.iter() {
+        for &v in row.iter() {
+            let valid =
+                v == 0 || (v > 0 && v <= 65_536 && (v & (v - 1) == 0)) || matches!(v, -1 | -2 | -4);
+            if !valid {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid tile value: {}",
+                    v
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Apply one move; if the board changes a new tile is spawned at random.
 ///
 /// :param list[list[int]] board:
@@ -54,6 +70,8 @@ fn step(py_board: &Bound<'_, PyAny>, direction: u8) -> PyResult<(Vec<Vec<i32>>, 
             board[r][c] = v;
         }
     }
+
+    validate_board(&board)?;
 
     // ② Map `direction` to `Action`
     let action = match direction {

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,4 +1,5 @@
 import akioi_2048 as ak
+import pytest
 
 
 def test_step_smoke():
@@ -85,3 +86,36 @@ def test_number_and_multiplier_no_merge_with_gap():
     assert new_board[2][0] == -2
     assert new_board[3][0] == 16
     assert delta == 0
+
+
+def test_step_rejects_non_power_of_two():
+    board = [
+        [3, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)
+
+
+def test_step_rejects_too_large_value():
+    board = [
+        [131072, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)
+
+
+def test_step_rejects_unknown_negative_multiplier():
+    board = [
+        [-3, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)


### PR DESCRIPTION
## Summary
- ensure `step` rejects tiles that aren't 0, powers of two up to 65536, or the multipliers -1/-2/-4
- add tests covering non-power-of-two, too-large, and unsupported negative tile values

## Testing
- `cargo check`
- `ruff check .`
- `mado check .` *(fails: command not found)*
- `maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb544506c832c85849f72bbd4ed7a