### PR TITLE
chore: note spawn tile probability mismatch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,8 @@ fn spawn_tile<R: Rng>(board: &mut Board, rng: &mut R) {
     let &(r, c) = empties.choose(rng).unwrap();
 
     // ③ Generate a tile using weighted probabilities
+    // TODO: The probabilities below do not match the documentation in
+    // `rules/source.php`. Update once the documentation is corrected.
     let p: f64 = rng.random();
     board[r][c] = if p < 0.783 {
         2


### PR DESCRIPTION
## Summary
- mark TODO explaining spawn tile probabilities don't match documentation

## Testing
- `cargo fmt --all`
- `ruff format`
- `cargo check`
- `ruff check .`
- `mado check .` *(fails: command not found)*
- `maturin develop` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'akioi_2048')*


------
https://chatgpt.com/codex/tasks/task_e_689eb5cea5a4832c87cd2c927c8d9d3a