### PR TITLE
Refine board rotation handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ fn idx_to_action(i: usize) -> Action {
 /// Rotate board 90°×k clockwise
 fn rotate(b: Board, k: usize) -> Board {
     let mut r = [[0; 4]; 4];
-    match k % 4 {
+    match k {
         0 => b,
         1 => {
             for i in 0..4 {
@@ -170,7 +170,7 @@ fn rotate(b: Board, k: usize) -> Board {
             }
             r
         }
-        _ => r,
+        _ => unreachable!("k must be 0..=3"),
     }
 }
 
@@ -280,4 +280,15 @@ fn akioi_2048(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(step, &m)?)?;
     m.add_function(wrap_pyfunction!(init, &m)?)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "k must be 0..=3")]
+    fn rotate_panics_on_invalid_k() {
+        rotate([[0; 4]; 4], 4);
+    }
 }


### PR DESCRIPTION
## Summary
- panic when `rotate` receives an invalid rotation count
- add unit test verifying invalid rotation panics

## Testing
- `cargo check`
- `cargo test`
- `ruff check .`
- `mado check .` *(fails: command not found)*
- `maturin develop` *(fails: command not found)*
- `pytest` *(fails: No module named 'akioi_2048')*

------
https://chatgpt.com/codex/tasks/task_e_689eb5de46d4832c8b29085fa2923fe5