### PR TITLE
docs: add mado install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@
 
 ## Development Workflow
 
+- Install `mado` using
+  `cargo install --git https://github.com/akiomik/mado mado` before making
+  changes.
 - Format Rust code with `cargo fmt --all` before committing.
 - Format Python code with `ruff format`.
 - Format Markdown with `npx @fsouza/prettierd`.


### PR DESCRIPTION
## Summary
- document how to install the `mado` tool before contributing

## Testing
- `cargo fmt --all`
- `ruff format`
- `npx @fsouza/prettierd AGENTS.md` *(fails: No files specified)*
- `npx prettier AGENTS.md --write`
- `cargo check`
- `ruff check .`
- `mado check .`
- `maturin develop`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb6e53b28832cb79163cc18d5226a