### PR TITLE
Reject invalid tile value 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,12 @@ enum Action {
     Right,
 }
 
-
 fn validate_board(board: &Board) -> PyResult<()> {
     for row in board.iter() {
         for &v in row.iter() {
-            let valid =
-                v == 0 || (v > 0 && v <= 65_536 && (v & (v - 1) == 0)) || matches!(v, -1 | -2 | -4);
+            let valid = v == 0
+                || (v >= 2 && v <= 65_536 && (v & (v - 1) == 0))
+                || matches!(v, -1 | -2 | -4);
             if !valid {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
                     "invalid tile value: {}",
@@ -40,7 +40,6 @@ fn validate_board(board: &Board) -> PyResult<()> {
 /// * `2` → **Up**    ↑
 /// * `3` → **Left**  ←
 const IDX_TO_ACTION: [Action; 4] = [Action::Down, Action::Right, Action::Up, Action::Left];
-
 
 /// Apply one move; if the board changes a new tile is spawned at random.
 ///

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -119,3 +119,14 @@ def test_step_rejects_unknown_negative_multiplier():
     ]
     with pytest.raises(ValueError):
         ak.step(board, 0)
+
+
+def test_step_rejects_one():
+    board = [
+        [1, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)


### PR DESCRIPTION
## Summary
- require numeric tiles to be at least 2 in `validate_board`
- add regression test ensuring boards containing 1 are rejected

## Testing
- `cargo check`
- `ruff check .`
- `mado check .`
- `maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ebdf5fcb8832cb352b161f94f4ef7