### PR TITLE
Clamp multiplier merges at 65k

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ enum Action {
     Right,
 }
 
-
 fn validate_board(board: &Board) -> PyResult<()> {
     for row in board.iter() {
         for &v in row.iter() {
@@ -40,7 +39,6 @@ fn validate_board(board: &Board) -> PyResult<()> {
 /// * `2` → **Up**    ↑
 /// * `3` → **Left**  ←
 const IDX_TO_ACTION: [Action; 4] = [Action::Down, Action::Right, Action::Up, Action::Left];
-
 
 /// Apply one move; if the board changes a new tile is spawned at random.
 ///
@@ -249,7 +247,8 @@ fn try_merge(a: i32, b: i32, adjacent: bool, below: &[i32]) -> Option<(i32, i32)
     if a * b < 0 && adjacent && (below.is_empty() || below.iter().all(|&v| v != 0)) {
         let num = if a > 0 { a } else { b };
         let mul = if a < 0 { a } else { b };
-        let v = num * mul.abs();
+        let mut v = num * mul.abs();
+        v = v.min(65_536);
         return Some((v, v));
     }
     None


### PR DESCRIPTION
## Summary
- Clamp numeric-plus-multiplier merge results to a maximum tile value of 65,536

## Testing
- `cargo check`
- `ruff check .`
- `mado check .`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ebdd97aa4832c8394fdc314eda742