### PR TITLE
Modularize game logic tests and expand coverage

### DIFF
--- a/tests/step/test_merges.py
+++ b/tests/step/test_merges.py
@@ -1,13 +1,4 @@
 import akioi_2048 as ak
-import pytest
-
-
-def test_step_smoke():
-    board = ak.init()
-    new_board, delta, msg = ak.step(board, 0)
-    assert len(new_board) == 4 and all(len(r) == 4 for r in new_board)
-    assert isinstance(delta, int)
-    assert msg in (-1, 0, 1)
 
 
 def test_number_merges_and_positive_score():
@@ -48,17 +39,17 @@ def test_no_merge_for_negative_four():
     assert delta == 0
 
 
-def test_down_move_without_merge():
+def test_number_and_multiplier_merge_with_tiles_below():
     board = [
-        [-1, 2, 0, 0],
         [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
+        [2, 0, 0, 0],
+        [-2, 0, 0, 0],
+        [4, 0, 0, 0],
     ]
     new_board, delta, _ = ak.step(board, 0)
-    assert new_board[3][0] == -1
-    assert new_board[3][1] == 2
-    assert delta == 0
+    assert new_board[3][0] == 8
+    assert new_board[2][0] == 2
+    assert delta == 8
 
 
 def test_number_and_multiplier_do_not_merge_without_tiles_below():
@@ -88,34 +79,14 @@ def test_number_and_multiplier_no_merge_with_gap():
     assert delta == 0
 
 
-def test_step_rejects_non_power_of_two():
+def test_single_tile_merges_only_once():
     board = [
-        [3, 0, 0, 0],
+        [2, 2, 2, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError):
-        ak.step(board, 0)
-
-
-def test_step_rejects_too_large_value():
-    board = [
-        [131072, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-    ]
-    with pytest.raises(ValueError):
-        ak.step(board, 0)
-
-
-def test_step_rejects_unknown_negative_multiplier():
-    board = [
-        [-3, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-        [0, 0, 0, 0],
-    ]
-    with pytest.raises(ValueError):
-        ak.step(board, 0)
+    new_board, delta, _ = ak.step(board, 3)
+    assert new_board[0][0] == 4
+    assert new_board[0][1] == 2
+    assert delta == 4

--- a/tests/step/test_moves.py
+++ b/tests/step/test_moves.py
@@ -1,0 +1,80 @@
+import akioi_2048 as ak
+import pytest
+
+
+def count_non_zero(board):
+    return sum(1 for row in board for cell in row if cell)
+
+
+@pytest.mark.parametrize("direction", [0, 1, 2, 3])
+def test_step_smoke_all_directions(direction):
+    board = ak.init()
+    new_board, delta, msg = ak.step(board, direction)
+    assert len(new_board) == 4 and all(len(r) == 4 for r in new_board)
+    assert isinstance(delta, int)
+    assert msg in (-1, 0, 1)
+
+
+def test_spawn_occurs_after_valid_move():
+    board = [
+        [0, 0, 0, 2],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, msg = ak.step(board, 3)
+    assert count_non_zero(new_board) == 2
+    assert delta == 0
+    assert msg in (-1, 0, 1)
+
+
+def test_no_spawn_when_move_invalid():
+    board = [
+        [2, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, msg = ak.step(board, 2)
+    assert new_board == board
+    assert delta == 0
+    assert msg == 0
+    assert count_non_zero(new_board) == 1
+
+
+def test_down_move_without_merge():
+    board = [
+        [-1, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 0)
+    assert new_board[3][0] == -1
+    assert new_board[3][1] == 2
+    assert delta == 0
+
+
+def test_move_left_merges_adjacent_pairs_correctly():
+    board = [
+        [2, 2, 4, 4],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 3)
+    assert new_board[0][0] == 4
+    assert new_board[0][1] == 8
+    assert delta == 12
+
+
+def test_move_up_combines_tiles():
+    board = [
+        [0, 0, 0, 0],
+        [2, 0, 0, 0],
+        [2, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, _ = ak.step(board, 2)
+    assert new_board[0][0] == 4
+    assert delta == 4

--- a/tests/step/test_state.py
+++ b/tests/step/test_state.py
@@ -1,0 +1,40 @@
+import akioi_2048 as ak
+
+
+def test_game_over_message_on_full_board_no_moves():
+    board = [
+        [2, 4, 8, 16],
+        [32, 64, 128, 256],
+        [512, 1024, 2048, 4096],
+        [8192, 16384, 32768, 8192],
+    ]
+    new_board, delta, msg = ak.step(board, 0)
+    assert new_board == board
+    assert delta == 0
+    assert msg == -1
+
+
+def test_victory_message_when_creating_65536():
+    board = [
+        [32768, 0, 0, 0],
+        [32768, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    new_board, delta, msg = ak.step(board, 0)
+    flat = [c for row in new_board for c in row]
+    assert 65536 in flat
+    assert delta == 65536
+    assert msg == 1
+
+
+def test_full_board_with_merge_available_not_game_over():
+    board = [
+        [2, 2, 4, 8],
+        [16, 32, 64, 128],
+        [256, 512, 1024, 2048],
+        [4096, 8192, 16384, 32768],
+    ]
+    new_board, _, msg = ak.step(board, 3)
+    assert msg == 0
+    assert new_board != board

--- a/tests/step/test_validation.py
+++ b/tests/step/test_validation.py
@@ -1,0 +1,59 @@
+import akioi_2048 as ak
+import pytest
+
+
+def test_step_rejects_invalid_direction():
+    board = ak.init()
+    with pytest.raises((ValueError, OverflowError)):
+        ak.step(board, -1)
+    with pytest.raises((ValueError, OverflowError)):
+        ak.step(board, 4)
+
+
+def test_step_rejects_non_integer_direction():
+    board = ak.init()
+    with pytest.raises((TypeError, ValueError)):
+        ak.step(board, 1.5)
+
+
+def test_step_rejects_non_4x4_board():
+    board = [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)
+
+
+def test_step_rejects_non_power_of_two():
+    board = [
+        [3, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)
+
+
+def test_step_rejects_too_large_value():
+    board = [
+        [131072, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)
+
+
+def test_step_rejects_unknown_negative_multiplier():
+    board = [
+        [-3, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    with pytest.raises(ValueError):
+        ak.step(board, 0)


### PR DESCRIPTION
## Summary
- split step tests into dedicated modules for moves, state, validation, and merges
- add new examples covering multi-merge moves, non-integer directions, and other edge cases

## Testing
- `cargo check`
- `ruff check .`
- `mado check .`
- `maturin develop`
- `python -m pytest`
- `npx @fsouza/prettierd README.md` *(fails: No files specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ebf33fb60832c8f925788da80a76e