### PR TITLE
Fix clippy warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,6 @@
 ## Development Workflow
 
 - Run `cargo clippy`, `uv tool run ruff check .`, and `mado check .` before pushing.
-- Run `uv venv .venv` and `source .venv/bin/activate` then `uv run maturin develop` followed by `uv run pytest` to execute the full test suite.
+- Run `uv venv .venv` and `source .venv/bin/activate` then
+  `uv run maturin develop` followed by `uv run pytest` to execute the full
+  test suite.


### PR DESCRIPTION
## Summary
- refactor board validation to use helper function and inline formatting
- streamline rotation, column sliding, and tile spawning loops
- wrap long development instruction line

## Testing
- `CLIPPY_CONF_DIR=/tmp/empty cargo clippy`
- `uv tool run ruff check .`
- `mado check .`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee891e70c832cb194ee317d94dbeb