### PR TITLE
Refine clippy lint configuration and remove unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,11 @@ all = "deny"                      # Clippy 基础合集
 cargo = "deny"                    # Cargo.toml 相关
 pedantic = "deny"                  # 吹毛求疵模式
 nursery = "deny"                   # 实验性规则
-restriction = "deny"               # 极限限制（包含 unwrap_used 等）
-
-# 注意：restriction 里已含 unwrap_used/expect_used/dbg_macro 等，
-# 不用再单列，避免重复
+unwrap_used = "deny"
+expect_used = "deny"
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+print_stdout = "deny"
+print_stderr = "deny"

--- a/src/board.rs
+++ b/src/board.rs
@@ -12,7 +12,7 @@ pub fn validate_board(board: &Board) -> PyResult<()> {
     for row in board {
         for &tile in row {
             let valid = tile == 0
-                || ((2..=65_536).contains(&tile) && is_power_of_two(tile))
+                || ((2..=0x0001_0000).contains(&tile) && is_power_of_two(tile))
                 || matches!(tile, -1 | -2 | -4);
             if !valid {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/game.rs
+++ b/src/game.rs
@@ -81,7 +81,7 @@ fn single_step(board: &Board, action: Action) -> (Board, i32, bool) {
         }
     }
     let next = rotate(work, (4 - rot) % 4);
-    let victory = next.iter().flatten().any(|&v| v == 65_536);
+    let victory = next.iter().flatten().any(|&v| v == 0x0001_0000);
     (next, delta, victory)
 }
 
@@ -154,7 +154,7 @@ pub fn slide_column(col: [i32; 4]) -> ([i32; 4], i32) {
 /// Determine and perform a merge
 fn try_merge(a: i32, b: i32, adjacent: bool, below: &[i32]) -> Option<(i32, i32)> {
     // numeric + numeric
-    if a > 0 && b > 0 && a == b && a < 65_536 {
+    if a > 0 && b > 0 && a == b && a < 0x0001_0000 {
         return Some((a + b, a + b));
     }
     // multiplier + multiplier
@@ -166,7 +166,7 @@ fn try_merge(a: i32, b: i32, adjacent: bool, below: &[i32]) -> Option<(i32, i32)
         let num = if a > 0 { a } else { b };
         let mul = if a < 0 { a } else { b };
         let mut v = num * mul.abs();
-        v = v.min(65_536);
+        v = v.min(0x0001_0000);
         return Some((v, v));
     }
     None
@@ -188,7 +188,9 @@ fn spawn_tile<R: Rng>(board: &mut Board, rng: &mut R) {
     }
 
     // ② Pick a random position
-    let &(r, c) = empties.choose(rng).unwrap();
+    let Some(&(r, c)) = empties.choose(rng) else {
+        return;
+    };
 
     // ③ Generate a tile using weighted probabilities
     // TODO: The probabilities below do not match the documentation in


### PR DESCRIPTION
## Summary
- enforce explicit clippy lints instead of blanket `restriction`
- avoid panic by replacing `unwrap` with safe `let...else`
- express 65,536 tile limit in hexadecimal

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv run maturin develop`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f0b6d63e0832c816afbb0b9c2e205