### PR TITLE
fix ruff issues and preserve docstrings

### DIFF
--- a/akioi_2048/__init__.py
+++ b/akioi_2048/__init__.py
@@ -1,1 +1,3 @@
-from .akioi_2048 import *  # noqa: F401,F403
+"""Python bindings for the 2048 engine."""
+
+from .akioi_2048 import *  # noqa: F403

--- a/akioi_2048/__init__.pyi
+++ b/akioi_2048/__init__.pyi
@@ -1,36 +1,39 @@
+# ruff: noqa: PYI021
 """Type hints for :mod:`akioi_2048`."""
 
-from typing import List, Tuple
+def step(
+    board: list[list[int]],
+    direction: int,
+) -> tuple[list[list[int]], int, int]:
+    """Apply one move.
 
-def step(board: List[List[int]], direction: int) -> Tuple[List[List[int]], int, int]:
+    If the board changes, a new tile appears in a random empty cell.
+
+    Args:
+        board: 4x4 game board. Positive numbers are normal tiles (2, 4, 8,
+            ...). Negative numbers are multipliers: -1=x1, -2=x2, -4=x4
+            (absolute value is the multiplier).
+        direction: Move direction (0=Down ↓, 1=Right →, 2=Up ↑, 3=Left ←).
+
+    Returns:
+        tuple[list[list[int]], int, int]: ``(new_board, delta_score, state)``.
+
+    The tuple contains:
+        * ``new_board``: Board after the move.
+        * ``delta_score``: Score gained or lost from merges.
+        * ``state``: Game state flag.
+            * ``1`` indicates a ``65536`` tile was created (Victory).
+            * ``-1`` indicates no legal moves remain (Game Over).
+            * ``0`` indicates the game continues.
+
+    Note:
+        If the board does not change, no tile is spawned,
+        ``delta_score = 0``, and ``state = 0``.
     """
-    Apply one move. If the board changes, a new tile appears in a random empty cell.
 
-    :param board: 4×4 game board.
-        * Positive numbers are normal tiles (2, 4, 8, …)
-        * Negative numbers are multipliers: -1=×1, -2=×2, -4=×4
-          (absolute value is the multiplier)
+def init() -> list[list[int]]:
+    """Create a new board with two starting tiles.
 
-    :param direction: Move direction (0=Down ↓, 1=Right →, 2=Up ↑, 3=Left ←)
-
-    :returns: *(new_board, delta_score, state)*
-        * **new_board** `list[list[int]]` Board after the move
-        * **delta_score** `int` Score gained or lost from merges
-        * **state** `int` Game state flag
-            * `1`  → created a `65536` tile → **Victory**
-            * `-1` → no legal moves remain → **Game Over**
-            * `0`  → game continues
-
-    :note: If the board does not change, no tile is spawned, ``delta_score = 0``,
-        and ``state = 0``.
+    Returns:
+        list[list[int]]: Fresh board ready for play.
     """
-    ...
-
-def init() -> List[List[int]]:
-    """
-    Create a new board with two starting tiles.
-
-    :returns: *new_board*
-        * **new_board** `list[list[int]]` Fresh board ready for play
-    """
-    ...

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for akioi_2048."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,13 +1,19 @@
+# ruff: noqa: PLR2004, S101
+
+"""Tests for :func:`akioi_2048.init`."""
+
 import akioi_2048 as ak
 
 ALLOWED = {-2, -1, 2, 4}
 
 
-def flatten(board):
+def flatten(board: list[list[int]]) -> list[int]:
+    """Flatten a board into a single list."""
     return [c for row in board for c in row]
 
 
-def test_init_board():
+def test_init_board() -> None:
+    """Initialize board with two tiles."""
     board = ak.init()
     flat = flatten(board)
     non_zero = [x for x in flat if x]

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,16 +1,27 @@
-import akioi_2048 as ak
+# ruff: noqa: PLR2004, S101
+
+"""Tests for :func:`akioi_2048.step`."""
+
 import pytest
 
+import akioi_2048 as ak
 
-def test_step_smoke():
+BOARD_SIZE = 4
+VALID_STATES = (-1, 0, 1)
+
+
+def test_step_smoke() -> None:
+    """Initialize a board and perform a simple step."""
     board = ak.init()
     new_board, delta, msg = ak.step(board, 0)
-    assert len(new_board) == 4 and all(len(r) == 4 for r in new_board)
+    assert len(new_board) == BOARD_SIZE
+    assert all(len(r) == BOARD_SIZE for r in new_board)
     assert isinstance(delta, int)
-    assert msg in (-1, 0, 1)
+    assert msg in VALID_STATES
 
 
-def test_number_merges_and_positive_score():
+def test_number_merges_and_positive_score() -> None:
+    """Numbers merge and increase the score."""
     board = [
         [2, 0, 0, 0],
         [2, 0, 0, 0],
@@ -23,7 +34,8 @@ def test_number_merges_and_positive_score():
     assert delta == 12
 
 
-def test_multiplier_merges_and_negative_score():
+def test_multiplier_merges_and_negative_score() -> None:
+    """Multipliers merge and decrease the score."""
     board = [
         [-1, 0, 0, 0],
         [-1, 0, 0, 0],
@@ -36,7 +48,8 @@ def test_multiplier_merges_and_negative_score():
     assert delta == -6
 
 
-def test_no_merge_for_negative_four():
+def test_no_merge_for_negative_four() -> None:
+    """Negative four tiles do not merge."""
     board = [
         [0, 0, 0, 0],
         [0, 0, 0, 0],
@@ -48,7 +61,8 @@ def test_no_merge_for_negative_four():
     assert delta == 0
 
 
-def test_down_move_without_merge():
+def test_down_move_without_merge() -> None:
+    """Down move shifts tiles without merging."""
     board = [
         [-1, 2, 0, 0],
         [0, 0, 0, 0],
@@ -61,7 +75,8 @@ def test_down_move_without_merge():
     assert delta == 0
 
 
-def test_number_and_multiplier_do_not_merge_without_tiles_below():
+def test_number_and_multiplier_do_not_merge_without_tiles_below() -> None:
+    """Number and multiplier stay separate without tiles below."""
     board = [
         [2, 0, 0, 0],
         [-2, 0, 0, 0],
@@ -74,7 +89,8 @@ def test_number_and_multiplier_do_not_merge_without_tiles_below():
     assert delta == 0
 
 
-def test_number_and_multiplier_no_merge_with_gap():
+def test_number_and_multiplier_no_merge_with_gap() -> None:
+    """Number and multiplier remain apart with a gap."""
     board = [
         [2, 0, 0, 0],
         [-2, 0, 0, 0],
@@ -88,45 +104,49 @@ def test_number_and_multiplier_no_merge_with_gap():
     assert delta == 0
 
 
-def test_step_rejects_non_power_of_two():
+def test_step_rejects_non_power_of_two() -> None:
+    """Reject tiles that are not powers of two."""
     board = [
         [3, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="^invalid tile value: 3$"):
         ak.step(board, 0)
 
 
-def test_step_rejects_too_large_value():
+def test_step_rejects_too_large_value() -> None:
+    """Reject tiles larger than the maximum allowed."""
     board = [
         [131072, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="^invalid tile value: 131072$"):
         ak.step(board, 0)
 
 
-def test_step_rejects_unknown_negative_multiplier():
+def test_step_rejects_unknown_negative_multiplier() -> None:
+    """Reject negative multipliers other than -1, -2, or -4."""
     board = [
         [-3, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="^invalid tile value: -3$"):
         ak.step(board, 0)
 
 
-def test_step_rejects_one():
+def test_step_rejects_one() -> None:
+    """Reject the value one, which is not allowed."""
     board = [
         [1, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="^invalid tile value: 1$"):
         ak.step(board, 0)


### PR DESCRIPTION
## Summary
- ensure stub uses modern generics and keep rich docstrings for LSP
- document and type annotate tests, matching expected errors explicitly
- add tests package initializer for Ruff namespace check

## Testing
- `cargo fmt --all`
- `uv tool run ruff format akioi_2048/__init__.py akioi_2048/__init__.pyi tests/test_step.py tests/__init__.py`
- `npx prettier --write "**/*.{md,yml,yaml,js,ts,json}"`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `mado check .`
- `uv venv .venv`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1203e1f4832cb0bd3965a771be59