### PR TITLE
fix: address ruff warnings

### DIFF
--- a/akioi_2048/__init__.py
+++ b/akioi_2048/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024 akioi
 """Python bindings for the 2048 engine."""
 
-from .akioi_2048 import * 
+from .akioi_2048 import init
+from .akioi_2048 import step
+
+__all__ = ["init", "step"]

--- a/akioi_2048/__init__.pyi
+++ b/akioi_2048/__init__.pyi
@@ -1,4 +1,4 @@
-# ruff: noqa: PYI021
+# Copyright (c) 2024 akioi
 """Type hints for :mod:`akioi_2048`."""
 
 def step(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2024 akioi
 """Test suite for akioi_2048."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,4 @@
-
-
+# Copyright (c) 2024 akioi
 """Tests for :func:`akioi_2048.init`."""
 
 import akioi_2048 as ak
@@ -8,7 +7,11 @@ ALLOWED = {-2, -1, 2, 4}
 
 
 def flatten(board: list[list[int]]) -> list[int]:
-    """Flatten a board into a single list."""
+    """Flatten a board into a single list.
+
+    Returns:
+        list[int]: A flattened list of all tile values.
+    """
     return [c for row in board for c in row]
 
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,5 +1,4 @@
-
-
+# Copyright (c) 2024 akioi
 """Tests for :func:`akioi_2048.step`."""
 
 import pytest
@@ -112,7 +111,7 @@ def test_step_rejects_non_power_of_two() -> None:
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError, match="^invalid tile value: 3$"):
+    with pytest.raises(ValueError, match=r"^invalid tile value: 3$"):
         ak.step(board, 0)
 
 
@@ -124,7 +123,7 @@ def test_step_rejects_too_large_value() -> None:
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError, match="^invalid tile value: 131072$"):
+    with pytest.raises(ValueError, match=r"^invalid tile value: 131072$"):
         ak.step(board, 0)
 
 
@@ -136,7 +135,7 @@ def test_step_rejects_unknown_negative_multiplier() -> None:
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError, match="^invalid tile value: -3$"):
+    with pytest.raises(ValueError, match=r"^invalid tile value: -3$"):
         ak.step(board, 0)
 
 
@@ -148,5 +147,5 @@ def test_step_rejects_one() -> None:
         [0, 0, 0, 0],
         [0, 0, 0, 0],
     ]
-    with pytest.raises(ValueError, match="^invalid tile value: 1$"):
+    with pytest.raises(ValueError, match=r"^invalid tile value: 1$"):
         ak.step(board, 0)


### PR DESCRIPTION
## Summary
- add copyright headers and explicit exports
- document helper return values and use raw regex strings

## Testing
- `cargo fmt --all`
- `uv tool run ruff format`
- `npx prettier --write "**/*.{md,yml,yaml,js,ts,json}"`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv venv .venv`
- `source .venv/bin/activate`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f1ecbe790832caeec2f6e5ff33a0d