### PR TITLE
chore: remove copyright comments from python files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"] # 生成 Python 扩展
 default = []
 python-bindings = [
   "pyo3/extension-module", # 产出可导入的 .so/.pyd
-  "pyo3/abi3-py38",       # 与 ≥3.8 的解释器 ABI 兼容
+  "pyo3/abi3-py38",        # 与 ≥3.8 的解释器 ABI 兼容
 ]
 
 
@@ -28,18 +28,18 @@ incremental = true # 提升二次编译速度
 
 [workspace.lints.rust]
 # rustc 自带
-warnings = "deny"                # 所有警告当错误
-rust-2021-idioms = "deny"         # 严格习惯用法检查（按项目 edition 调整）
-missing_docs = "deny"             # 公共 API 必须写文档
-unused_must_use = "deny"          # 必须处理 #[must_use] 返回值
-unreachable_pub = "deny"          # 避免暴露内部符号
+warnings = "deny"         # 所有警告当错误
+rust-2021-idioms = "deny" # 严格习惯用法检查（按项目 edition 调整）
+missing_docs = "deny"     # 公共 API 必须写文档
+unused_must_use = "deny"  # 必须处理 #[must_use] 返回值
+unreachable_pub = "deny"  # 避免暴露内部符号
 
 [lints.clippy]
 # 所有主要组
-all = "deny"                      # Clippy 基础合集
-cargo = "deny"                    # Cargo.toml 相关
-pedantic = "deny"                  # 吹毛求疵模式
-nursery = "deny"                   # 实验性规则
+all = "deny"           # Clippy 基础合集
+cargo = "deny"         # Cargo.toml 相关
+pedantic = "deny"      # 吹毛求疵模式
+nursery = "deny"       # 实验性规则
 unwrap_used = "deny"
 expect_used = "deny"
 dbg_macro = "deny"

--- a/akioi_2048/__init__.py
+++ b/akioi_2048/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2024 akioi
 """Python bindings for the 2048 engine."""
 
 from .akioi_2048 import init

--- a/akioi_2048/__init__.pyi
+++ b/akioi_2048/__init__.pyi
@@ -1,4 +1,3 @@
-# Copyright (c) 2024 akioi
 """Type hints for :mod:`akioi_2048`."""
 
 def step(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "akioi backend"
 authors = [{ name = "jasonxue" }]
 requires-python = ">=3.8,<3.14"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 
 [build-system]
 requires = ["maturin>=1.9.3"]
@@ -18,9 +18,4 @@ features = ["python-bindings"]
 include = ["akioi_2048/__init__.py", "akioi_2048/__init__.pyi"]
 
 [dependency-groups]
-dev = [
-    "pytest>=7.4.4,<8",
-    "ruff>=0.12.9",
-    "maturin>=1.9.3",
-]
-
+dev = ["pytest>=7.4.4,<8", "ruff>=0.12.9", "maturin>=1.9.3"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@ fix = true
 unsafe-fixes = true
 
 [per-file-ignores]
-"tests/**" = ["S101","PLR2004"]
+"tests/**" = ["S101", "PLR2004"]
 "*.pyi" = ["PYI021"]
 
 
@@ -27,7 +27,13 @@ lines-after-imports = 1
 lines-between-types = 1
 order-by-type = true
 relative-imports-order = "closest-to-furthest"
-section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "first-party",
+  "local-folder",
+]
 known-first-party = ["src"]
 
 [lint.pydocstyle]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,1 @@
-# Copyright (c) 2024 akioi
 """Test suite for akioi_2048."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2024 akioi
 """Tests for :func:`akioi_2048.init`."""
 
 import akioi_2048 as ak

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2024 akioi
 """Tests for :func:`akioi_2048.step`."""
 
 import pytest


### PR DESCRIPTION
## Summary
- remove copyright headers from Python package and test modules
- format Cargo.toml, pyproject.toml, and ruff.toml using project formatting script

## Testing
- `cargo fmt --all`
- `uv tool run ruff format`
- `npx prettier --write "**/*.{md,yml,yaml,js,ts,json}"`
- `taplo format "**/*.toml"`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv venv .venv`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f258ee874832cadf312172ba6f597