### PR TITLE
Use intrinsic power-of-two check for board validation

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -3,16 +3,13 @@ use pyo3::prelude::*;
 /// 4×4 board grid type
 pub type Board = [[i32; 4]; 4];
 
-pub const fn is_power_of_two(value: i32) -> bool {
-    value > 0 && (value & (value - 1)) == 0
-}
-
 /// Ensure all tiles on the board are valid
 pub fn validate_board(board: &Board) -> PyResult<()> {
     for row in board {
         for &tile in row {
             let valid = tile == 0
-                || ((2..=0x0001_0000).contains(&tile) && is_power_of_two(tile))
+                || ((2..=0x0001_0000).contains(&tile)
+                    && u32::try_from(tile).is_ok_and(u32::is_power_of_two))
                 || matches!(tile, -1 | -2 | -4);
             if !valid {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(


### PR DESCRIPTION
## Summary
- drop custom `PowerOfTwo` trait and use `u32::is_power_of_two` with `try_from`
- call intrinsic check in board validation while keeping positive range constraint

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv venv .venv`
- `source .venv/bin/activate`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2dce070c832c922d8a9dcd551336