### PR TITLE
ci: add windows arm64 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -235,6 +235,37 @@ jobs:
                   name: wheels-win-x86
                   path: dist\*.whl
 
+    # Build wheels for Windows arm64
+    build-windows-arm64:
+        runs-on: windows-latest
+        env:
+            CIBW_ARCHS_WINDOWS: "ARM64"
+            CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/cache@v4
+              with:
+                  path: ~\\AppData\\Local\\pip\\Cache
+                  key: win-arm64-pip-${{ hashFiles('pyproject.toml') }}
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Install build tools
+              run: |
+                  python -m pip install -U pip
+                  pip install cibuildwheel maturin
+
+            - name: Build Windows arm64 wheels
+              run: python -m cibuildwheel --output-dir dist
+
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: wheels-win-arm64
+                  path: dist\\*.whl
+
     # Build source distribution
     build-sdist:
         runs-on: ubuntu-latest
@@ -264,6 +295,7 @@ jobs:
             - build-macos-x86_64
             - build-windows-amd64
             - build-windows-x86
+            - build-windows-arm64
             - build-sdist
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
## Summary
- add Windows arm64 wheel build to release workflow
- include new job in publish dependencies

## Testing
- `cargo fmt --all`
- `uv tool run ruff format`
- `npx prettier --write "**/*.{md,yml,yaml,js,ts,json}"`
- `taplo format "**/*.toml"`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv venv .venv`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4860a8cc832c88b4b4a27a3a9f10