### PR TITLE
chore: format ruff config

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -34,10 +34,5 @@ section-order = [
 known-first-party = ["src"]
 
 
-
-
-
-
-
 [lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
## Summary
- remove redundant blank lines in ruff configuration for consistent formatting

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `uv tool run ruff check .`
- `mado check .`
- `uv venv .venv`
- `uv run maturin develop`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a030e15e20832c9abf90e900c17983